### PR TITLE
Remove várias pinagens pois agora temos no versions.cfg

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -36,20 +36,10 @@ recipe = collective.recipe.omelette
 eggs = ${test:eggs}
 
 [versions]
-plone.app.contenttypes = 1.0
-zope.configuration = 3.8.0
-
 # use latest version of coverage and setuptools
 coverage =
 setuptools =
-# XXX: https://github.com/zheller/flake8-quotes/issues/23
-flake8-quotes = 0.1.2
 
-# FIXME: Pinagem para não quebrar o build. Necessária enquanto relato
-# https://github.com/collective/collective.cover/issues/492 não for resolvido.
-# Versão 3.3.1 de collective.js.bootstrap passa a pedir como dependência
-# plone.app.jquery>=1.8.3, dando conflito no release do Plone 4.3.x.
-collective.js.bootstrap = 2.3.1.1
 # Necessário colocar o pacote com versão vazia para que o versison.cfg do release
 # mais novo do extends não sobrescreva o próprio pacote.
 brasil.gov.agenda =


### PR DESCRIPTION
Remove:

    plone.app.contenttypes
    zope.configuration
    collective.js.bootstrap

Por já termos em https://github.com/plonegovbr/portal.buildout/blob/2b20e5a2f69a043aff7939d3bb2cfcdd8b2bc677/buildout.d/versions.cfg, que é usado no extends de buildout.cfg.

Remove:

    flake8-quotes

Por ter sido resolvido em https://github.com/zheller/flake8-quotes/issues/23.