### PR TITLE
Adiciona indexação dos itens de brasil.gov.agenda.

### DIFF
--- a/src/brasil/gov/agenda/upgrades/v4004/__init__.py
+++ b/src/brasil/gov/agenda/upgrades/v4004/__init__.py
@@ -17,10 +17,10 @@ def fix_subjects_on_agendas(setup_tool):
     logger.info('{0} items will be analyzed'.format(len(results)))
     n = 0
     for obj in get_valid_objects(results):
-        if obj.subjects is not None:
-            continue
+        if obj.subjects is None:
+            obj.subjects = ()
 
-        obj.subjects = ()
+        catalog.catalog_object(obj)
         n += 1
         if n % 1000 == 0 and not test:
             transaction.commit()


### PR DESCRIPTION
Dessa forma, itens passam a aparecer no portlet definido por collective.portlet.calendar. Ver https://github.com/plonegovbr/brasil.gov.agenda/issues/82#issuecomment-396281212 para mais detalhes.