### PR TITLE
Adiciona cssselect como dependência

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,6 +7,7 @@ extends =
 package-name = brasil.gov.agenda
 package-extras = [test]
 eggs +=
+    cssselect  # XXX: needed by plone.protect
     z3c.unconfigure
 
 parts +=


### PR DESCRIPTION
Ver https://github.com/plonegovbr/brasil.gov.agenda/pull/106#discussion_r198485728. Sem essa dependência dá erro no plone.protect devido à versão mais nova de lxml. Relacionado: https://github.com/plone/plone.protect/issues/79