### PR TITLE
Remove conditional inclussion of subscribers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0a3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Remove o registro condicional de subscribers incluído no release 2.0a1.
+  [hvelarde]
+
 - Marca dias com compromissos nos calendários (closes `#118 <https://github.com/plonegovbr/brasil.gov.agenda/issues/118>`_).
   [rodfersou]
 

--- a/src/brasil/gov/agenda/configure.zcml
+++ b/src/brasil/gov/agenda/configure.zcml
@@ -3,7 +3,6 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="brasil.gov.agenda">
 
     <five:registerPackage package="." />
@@ -28,10 +27,7 @@
     <include package=".caching" />
     <include package=".content" />
     <include package=".portlets" />
-    <include
-        zcml:condition="not-installed transmogrify.dexterity"
-        package=".subscribers"
-        />
+    <include package=".subscribers" />
 
     <!-- Suporte a arquivos estaticos -->
     <browser:resourceDirectory name="brasil.gov.agenda" directory="static" />


### PR DESCRIPTION
This reverts the change made in 13093048790b097816ce39adf29d0a4137e6909f, as we are facing issues on sites that have transmogrify.dexterity installed after migration.

The change was included to avoid an `AttributeError` while migrating content.

We'll need to find a different workaround for this in the future in case needed.