### PR TITLE
Atualiza versão do Firefox no Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
 - python bootstrap.py
 - bin/buildout annotate
 - bin/buildout
+before_script:
+  - firefox -v
 script:
 - bin/code-analysis
 - bin/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ services:
   - xvfb
 language: python
 python: 2.7
+addons:
+  apt:
+    packages:
+      - firefox-geckodriver
 cache:
   directories:
   - $HOME/.pylint.d
   - eggs
   - parts/node
-addons:
-  # XXX: use an older Firefox ESR as we are stuck with selenium = 2.53.5
-  #      https://github.com/SeleniumHQ/selenium/issues/2739#issuecomment-249482533
-  firefox: 45.9.0esr
 matrix:
   fast_finish: true
 before_install:

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -57,6 +57,11 @@ short_name = brasilgovagenda
 # mais novo do extends não sobrescreva o próprio pacote.
 brasil.gov.agenda =
 
+# FIXME: Necessário para utilizar firefox mais novo nos testes robot.
+# Despinar quando esta pinagem for migrada para:
+# https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg
+selenium = 3.14.1
+
 # É necessário ter o precompile para gerar os '*.mo' para os testes. Os '*.mo'
 # só são gerados quando a instância sobe e para executar os testes a instância
 # não é levantada.

--- a/src/brasil/gov/agenda/tests/keywords.robot
+++ b/src/brasil/gov/agenda/tests/keywords.robot
@@ -22,6 +22,7 @@ Click Adicionar Agenda
     Page Should Contain  Adicionar Agenda
 
 Click Adicionar AgendaDiaria
+    Wait Until Page Contains Element  css=a#agendadiaria
     Open Add New Menu
     Click Link  css=a#agendadiaria
     Page Should Contain  Adicionar Agenda Diária


### PR DESCRIPTION
Hoje nas máquinas locais, temos versões bem mais novas que a que estava sendo utilizada no Travis. É bom atualizar a versão do Travis para ser uma versão mais perto da que utilizamos localmente.

Para utilizar uma versão mais nova, é necessário atualizar a versão do selenium e instalar o geckodriver. Ver:

SeleniumHQ/selenium#2739 (comment)

