### PR TITLE
Não exibe link para dias com agenda diária privada

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,16 @@ Changelog
 2.0b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Não exibe link para dias com agenda diária privada nos links para dias da
+  semana, se o usuário é anônimo.
+  (closes `#plonegovbr/brasil.gov.agenda#166 <https://github.com/plonegovbr/brasil.gov.agenda/issues/166>`_).
+  [idgserpro]
 
 
 2.0b2 (2019-04-05)
 ^^^^^^^^^^^^^^^^^^
 
-- Acrescenta o campo 'Solicitante' no tipo de conteúdo ``Compromisso``. 
+- Acrescenta o campo 'Solicitante' no tipo de conteúdo ``Compromisso``.
   (closes `#plonegovbr/brasil.gov.agenda#153 <https://github.com/plonegovbr/brasil.gov.agenda/issues/153>`_).
   [idgserpro]
 

--- a/src/brasil/gov/agenda/browser/mixin.py
+++ b/src/brasil/gov/agenda/browser/mixin.py
@@ -24,6 +24,13 @@ class AgendaMixin:
                               context=self.context,
                               target_language=target_language)
 
+    def has_appointment(self, day):
+        """Verifica se um determinado dia possui agenda diária."""
+        ad = self.agenda.get(day.strftime(AGENDADIARIAFMT), False)
+        if ad and api.user.has_permission('View', obj=ad):
+            return True
+        return False
+
     def month(self):
         tool = api.portal.get_tool('translation_service')
         strmonth = self._translate(tool.month_msgid(self.date.strftime('%m')))
@@ -44,7 +51,7 @@ class AgendaMixin:
             has_appointment = False
             if day == self.date:
                 cssclass.append('is-selected')
-            if self.agenda.get(day.strftime(AGENDADIARIAFMT), False):
+            if self.has_appointment(day):
                 has_appointment = True
                 cssclass.append('has-appointment')
             # Weekday difference between datetime and DateTime objects

--- a/src/brasil/gov/agenda/browser/templates/agenda_macros.pt
+++ b/src/brasil/gov/agenda/browser/templates/agenda_macros.pt
@@ -24,10 +24,11 @@
 
 <metal:form define-macro="daypicker"
             i18n:domain="brasil.gov.agenda">
-  <div class="daypicker-wrapper">
+  <div class="daypicker-wrapper"
+       tal:define="days view/days">
     <ul class="daypicker"
-        tal:condition="view/days">
-      <tal:event repeat="day view/days">
+        tal:condition="days">
+      <tal:event repeat="day days">
         <li tal:attributes="data-day day/dayurl;
                             class day/cssclass;">
           <a tal:attributes="href string:${view/agenda/absolute_url}/${day/dayurl}"


### PR DESCRIPTION
Não exibe link para dias com agenda diária privada nos links para dias  da semana, se o usuário é anônimo.

Fix #166