### PR TITLE
Pina setuptools = 41.6.0

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -57,6 +57,15 @@ short_name = brasilgovagenda
 # mais novo do extends não sobrescreva o próprio pacote.
 brasil.gov.agenda =
 
+# FIXME: Corrige erro:
+#    OSError: [Errno 39] Directory not empty
+# backports.functools_lru_cache 1.6+ utiliza setup_requires no setup.cfg, e,
+# para isso, é necessário setuptools >= 36.7.0. Ver:
+# https://github.com/pypa/setuptools/blob/a0fe403c141369defacf12dccbdc01634bbcb1da/CHANGES.rst#v3670
+# Despinar quando esta pinagem for migrada para:
+# https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg
+setuptools = 41.6.0
+
 # FIXME: Necessário para utilizar firefox mais novo nos testes robot.
 # Despinar quando esta pinagem for migrada para:
 # https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg


### PR DESCRIPTION
Corrige erro:

    OSError: [Errno 39] Directory not empty

`backports.functools_lru_cache` 1.6+ utiliza setup_requires no setup.cfg,
e, para isso, é necessário `setuptools >= 36.7.0`. Ver:

https://github.com/pypa/setuptools/blob/a0fe403c141369defacf12dccbdc01634bbcb1da/CHANGES.rst#v3670