### PR TITLE
Não desloca mês corrente para o terceiro calendário, ao clicar em um dia

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.0b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Não desloca mês corrente para o terceiro calendário, ao clicar em um dia do
+  mês atual.
+  (closes `#162 <https://github.com/plonegovbr/brasil.gov.agenda/issues/162>`_).
+  [idgserpro]
+
 - Não exibe link para dias com agenda diária privada nos links para dias da
   semana, se o usuário é anônimo.
   (closes `#plonegovbr/brasil.gov.agenda#166 <https://github.com/plonegovbr/brasil.gov.agenda/issues/166>`_).

--- a/src/brasil/gov/agenda/tests/keywords.robot
+++ b/src/brasil/gov/agenda/tests/keywords.robot
@@ -2,17 +2,24 @@
 
 Resource  plone/app/robotframework/keywords.robot
 Library  Remote  ${PLONE_URL}/RobotRemote
-Variables  brasil/gov/agenda/tests/variables.py
 
 *** Variables ***
 
 ${title_selector} =  input#form-widgets-IBasic-title
+${title_compromisso_selector} =  input#form-widgets-title
 ${description_selector} =  textarea#form-widgets-IBasic-description
+${description_compromisso_selector} =  textarea#form-widgets-description
 ${autoridade_selector} =  input#form-widgets-autoridade
 ${orgao_selector} =  input#form-widgets-orgao
 ${date_day_selector} =  select#form-widgets-date-day
 ${date_month_selector} =  select#form-widgets-date-month
 ${date_year_selector} =  select#form-widgets-date-year
+${start_day_selector} =  select#form-widgets-start_date-day
+${start_month_selector} =  select#form-widgets-start_date-month
+${start_year_selector} =  select#form-widgets-start_date-year
+${end_day_selector} =  select#form-widgets-end_date-day
+${end_month_selector} =  select#form-widgets-end_date-month
+${end_year_selector} =  select#form-widgets-end_date-year
 
 *** Keywords ***
 
@@ -26,6 +33,12 @@ Click Adicionar AgendaDiaria
     Open Add New Menu
     Click Link  css=a#agendadiaria
     Page Should Contain  Adicionar Agenda Diária
+
+Click Adicionar Compromisso
+    Wait Until Page Contains Element  css=a#compromisso
+    Open Add New Menu
+    Click Link  css=a#compromisso
+    Page Should Contain  Adicionar Compromisso
 
 Create Agenda
     [arguments]  ${title}  ${description}  ${autoridade}
@@ -49,3 +62,18 @@ Create AgendaDiaria
     Page Should Contain  ${dia}
     Page Should Contain  de
     Page Should Contain  ${ano}
+
+Create Compromisso
+    [arguments]  ${title}  ${description}  ${start_day}  ${start_month}  ${start_year}  ${end_day}  ${end_month}  ${end_year}
+
+    Click Adicionar Compromisso
+    Input Text  css=${title_compromisso_selector}  ${title}
+    Input Text  css=${description_compromisso_selector}  ${description}
+    Select From List  css=${start_day_selector}  ${start_day}
+    Select From List  css=${start_year_selector}  ${start_year}
+    Select From List  css=${start_month_selector}  ${start_month}
+    Select From List  css=${end_day_selector}  ${end_day}
+    Select From List  css=${end_year_selector}  ${end_year}
+    Select From List  css=${end_month_selector}  ${end_month}
+    Click Button  Salvar
+    Page Should Contain  Voce vê esta página

--- a/src/brasil/gov/agenda/tests/test_clica_dia.robot
+++ b/src/brasil/gov/agenda/tests/test_clica_dia.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+
+Resource  brasil/gov/agenda/tests/keywords.robot
+
+Test Setup  Open test browser
+Test Teardown  Close all browsers
+
+*** Variables ***
+
+${day_selector} =  //a[contains(@class, 'ui-state-default')][text()='10']
+
+*** Test cases ***
+
+Test Clica Dia
+    Enable Autologin as  Site Administrator
+    Go to homepage
+
+    Create Agenda  Agenda do Presidente  Esta é a agenda do presidente  Machado de Assis
+    Create Compromisso  Compromisso  Descrição  10  10  2019  10  10  2019
+    Click Link  Agenda do Presidente
+    Create Compromisso  Compromisso  Descrição  11  10  2019  11  10  2019
+    Click Link  Agenda de Machado de Assis para 11/10/2019
+    Element Should Become Visible  xpath=${day_selector}
+    Click Element  xpath=${day_selector}
+    # Ao clicar no dia, o dia corrente não pode ir para o treceiro calendário .ui-datepicker-group-last
+    Page Should Not Contain Element  css=.ui-datepicker-group-last .ui-datepicker-current-day

--- a/src/brasil/gov/agenda/tests/test_compromisso.robot
+++ b/src/brasil/gov/agenda/tests/test_compromisso.robot
@@ -1,7 +1,6 @@
 *** Settings ***
 
 Resource  brasil/gov/agenda/tests/keywords.robot
-Variables  plone/app/testing/interfaces.py
 
 Test Setup  Open test browser
 Test Teardown  Close all browsers
@@ -10,19 +9,11 @@ Test Teardown  Close all browsers
 
 ${title_basic_selector} =  input#form-widgets-IBasic-title
 ${description_basic_selector} =  textarea#form-widgets-IBasic-description
-${title_selector} =  input#form-widgets-title
-${description_selector} =  textarea#form-widgets-description
 ${autoridade_selector} =  input#form-widgets-autoridade
 ${orgao_selector} =  input#form-widgets-orgao
 ${attendees_selector} =  textarea#form-widgets-attendees
-${start_day_selector} =  select#form-widgets-start_date-day
-${start_month_selector} =  select#form-widgets-start_date-month
-${start_year_selector} =  select#form-widgets-start_date-year
 ${start_hour_selector} =  select#form-widgets-start_date-hour
 ${start_min_selector} =  select#form-widgets-start_date-minute
-${end_day_selector} =  select#form-widgets-end_date-day
-${end_month_selector} =  select#form-widgets-end_date-month
-${end_year_selector} =  select#form-widgets-end_date-year
 ${end_hour_selector} =  select#form-widgets-end_date-hour
 ${end_min_selector} =  select#form-widgets-end_date-minute
 
@@ -57,7 +48,7 @@ Test Edit Delete Compromisso AgendaDiaria
     Click Link  Agenda de Clarice Lispector para 28/10/2013
     Page Should Contain  Júlio Verne
     Click Link  css=.editar_compromisso
-    Input Text  css=${title_selector}  Madre Teresa
+    Input Text  css=${title_compromisso_selector}  Madre Teresa
     Click Button  css=#form-buttons-save
     Wait Until Page Contains  Madre Teresa
     Click Link  css=.remover_compromisso
@@ -95,8 +86,8 @@ Create
     [arguments]  ${title}  ${description}
 
     Click Adicionar Compromisso
-    Input Text  css=${title_selector}  ${title}
-    Input Text  css=${description_selector}  ${description}
+    Input Text  css=${title_compromisso_selector}  ${title}
+    Input Text  css=${description_compromisso_selector}  ${description}
     Select From List  css=${start_day_selector}  28
     Select From List  css=${start_year_selector}  2013
     Select From List  css=${start_month_selector}  10
@@ -117,8 +108,8 @@ Update
     [arguments]  ${title}  ${description}
 
     Click Link  link=Edição
-    Input Text  css=${title_selector}  ${title}
-    Input Text  css=${description_selector}  ${description}
+    Input Text  css=${title_compromisso_selector}  ${title}
+    Input Text  css=${description_compromisso_selector}  ${description}
     Click Button  Salvar
     Page Should Contain  Alterações salvas
 

--- a/webpack/app/js/datepicker.js
+++ b/webpack/app/js/datepicker.js
@@ -100,18 +100,23 @@ export default class DatePicker {
   initMonthPicker() {
     // this event is needed to get right translation
     $(window).on('load', function() {
-      let onSelect = function(dateText, inst) { 
+      let onSelect = function(dateText, inst) {
         this.year = inst.selectedYear;
         this.month = inst.selectedMonth;
         this.day = parseInt(inst.selectedDay);
         if (this.is3calendar === true) {
+          // Faz com que o datepicker não seja recarregado antes do
+          // redirecionamento, evitando que o mês atual seja deslocado para o
+          // terceiro calendário. Ver:
+          // https://github.com/jquery/jquery-ui/blob/1.10.2/ui/jquery.ui.datepicker.js#L1014-L1015
+          inst.inline = false;
           // https://stackoverflow.com/a/19374679
           window.location = `${this.agendaURL}/${this.year}-${zfill(this.month + 1)}-${zfill(this.day)}`;
         } else {
           this.update();
         }
       };
-      let beforeShowDay = function(date) { 
+      let beforeShowDay = function(date) {
         let day = date.toISOString().slice(0, 10);
         if (this.daysWithAppointments.indexOf(day) >= 0) {
           return [true, 'ui-has-appointments', ''];
@@ -128,7 +133,7 @@ export default class DatePicker {
         onSelect: onSelect.bind(this),
         beforeShowDay: beforeShowDay.bind(this),
         onChangeMonthYear: onChangeMonthYear.bind(this),
-      }; 
+      };
       if (this.is3calendar) {
         options.numberOfMonths = 3;
       } else {


### PR DESCRIPTION
Foi necessário setar `inst.inline = false` no método `onSelect`. Isso faz
com que o datepicker não recarregue o calendário antes de redirecionar
para o dia selecionado. Ver:

https://github.com/jquery/jquery-ui/blob/1.10.2/ui/jquery.ui.datepicker.js#L1014-L1015

Fix #162